### PR TITLE
Scaffold services with docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,14 @@ volumes:
 * Conventional Commits
 * ESLint + Prettier + Husky
 * CI: GitHub Actions
+
+## 14. Local Development
+
+A `docker-compose.yml` is provided to spin up all services:
+
+```bash
+docker compose up --build
+```
+
+This brings up the NestJS API, the Expo client, PostgreSQL and Redis.
+The client is served on [http://localhost:19006](http://localhost:19006) and the API on [http://localhost:4000](http://localhost:4000).

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install && npm cache clean --force
+COPY src ./src
+RUN npm run build
+CMD ["npm", "run", "start:dev"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pokerbender-backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "node dist/main.js",
+    "start:dev": "ts-node-dev --respawn src/main.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.0.4"
+  }
+}

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+@Module({
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(4000);
+}
+
+bootstrap();

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "exclude": ["node_modules"]
+}

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+web

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Welcome to The Last Pokerbender</Text>
+    </View>
+  );
+}

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+RUN npm install -g expo-cli
+COPY package.json tsconfig.json ./
+RUN npm install && npm cache clean --force
+COPY . .
+CMD ["npm", "run", "start"]

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pokerbender-client",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start --dev-client"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4"
+  }
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "module": "esnext",
+    "target": "es2017",
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.9"
+services:
+  api:
+    build: ./backend
+    ports:
+      - "4000:4000"
+    environment:
+      - NODE_ENV=development
+    depends_on:
+      - db
+      - redis
+  client:
+    build: ./client
+    ports:
+      - "19006:19006"
+    environment:
+      - EXPO_DEVTOOLS_LISTEN_ADDRESS=0.0.0.0
+    depends_on:
+      - api
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: poker
+      POSTGRES_PASSWORD: pokerpass
+      POSTGRES_DB: pokerbender
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  redis:
+    image: redis:7-alpine
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add NestJS backend skeleton
- add Expo client skeleton
- add Docker compose with Postgres and Redis
- document compose usage in README

## Testing
- `npm --version`
- `cd backend && npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68682d7e0da08321b341e1146d92879f