### PR TITLE
Add DB init and health endpoints

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,8 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "pg": "^8.11.1"
   },
   "devDependencies": {
     "ts-node-dev": "^2.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { HealthController } from './health.controller';
+import { DatabaseService } from './database.service';
 
 @Module({
-  controllers: [AppController],
-  providers: [AppService],
+  controllers: [AppController, HealthController],
+  providers: [AppService, DatabaseService],
 })
 export class AppModule {}

--- a/backend/src/database.service.ts
+++ b/backend/src/database.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { Pool } from 'pg';
+
+@Injectable()
+export class DatabaseService implements OnModuleDestroy {
+  private pool: Pool;
+
+  constructor() {
+    this.pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  }
+
+  async query(sql: string) {
+    const client = await this.pool.connect();
+    try {
+      return await client.query(sql);
+    } finally {
+      client.release();
+    }
+  }
+
+  async onModuleDestroy() {
+    await this.pool.end();
+  }
+}

--- a/backend/src/health.controller.ts
+++ b/backend/src/health.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get } from '@nestjs/common';
+import { DatabaseService } from './database.service';
+
+@Controller('health')
+export class HealthController {
+  constructor(private readonly db: DatabaseService) {}
+
+  @Get()
+  getHealth() {
+    return { status: 'ok' };
+  }
+
+  @Get('db')
+  async getDbHealth() {
+    await this.db.query('SELECT 1');
+    return { db: 'ok' };
+  }
+}

--- a/db/init/01_create_tables.sql
+++ b/db/init/01_create_tables.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    email TEXT NOT NULL,
+    display_name TEXT,
+    created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/db/init/02_seed.sql
+++ b/db/init/02_seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO users (email, display_name) VALUES ('test@example.com', 'Tester');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "4000:4000"
     environment:
       - NODE_ENV=development
+      - DATABASE_URL=postgresql://poker:pokerpass@db:5432/pokerbender
     depends_on:
       - db
       - redis
@@ -25,6 +26,7 @@ services:
       POSTGRES_DB: pokerbender
     volumes:
       - db_data:/var/lib/postgresql/data
+      - ./db/init:/docker-entrypoint-initdb.d:ro
   redis:
     image: redis:7-alpine
 volumes:


### PR DESCRIPTION
## Summary
- add database initialization scripts
- mount init scripts in `docker-compose.yml`
- connect backend to Postgres
- expose `GET /health` and `GET /health/db`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6868366999b083219486b943c3d00f83