### PR TITLE
Add CI healthcheck via docker compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  healthcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Start services
+        run: docker compose up -d --build db redis api
+      - name: Test health endpoint
+        run: ./scripts/test_health.sh
+      - name: Stop services
+        if: always()
+        run: docker compose down

--- a/scripts/test_health.sh
+++ b/scripts/test_health.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+MAX_ATTEMPTS=10
+ATTEMPT=1
+until curl -sf http://localhost:4000/health > /tmp/health.json; do
+  if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+    echo "API did not become healthy in time" >&2
+    exit 1
+  fi
+  echo "Waiting for API... ($ATTEMPT/$MAX_ATTEMPTS)"
+  ATTEMPT=$((ATTEMPT+1))
+  sleep 3
+done
+grep -q '"status":"ok"' /tmp/health.json && echo "Health endpoint OK"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that spins up docker-compose
- check backend health endpoint via simple script

## Testing
- `npm run build` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68683a2e8b1c83218b9b89e8968c2388