### PR TITLE
Fix missing Node dependencies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "pg": "^8.11.1"

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,8 @@
   "dependencies": {
     "expo": "^49.0.0",
     "react": "18.2.0",
-    "react-native": "0.72.4"
+    "react-native": "0.72.4",
+    "typescript": "^5.1.3",
+    "@types/react": "~18.2.14"
   }
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "moduleResolution": "node"
   }
 }


### PR DESCRIPTION
## Summary
- add `@nestjs/platform-express` to backend
- install TypeScript and React types in client
- configure module resolution for the client tsconfig

## Testing
- `npm run build` in `backend`
- `npx tsc --noEmit` in `client` *(fails: Could not find a declaration file for module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68683d45915c832193cc5f0e93f957c7