### PR TITLE
Add card management API and logging

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,9 +3,11 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { HealthController } from './health.controller';
 import { DatabaseService } from './database.service';
+import { CardController } from './card.controller';
+import { CardService } from './card.service';
 
 @Module({
-  controllers: [AppController, HealthController],
-  providers: [AppService, DatabaseService],
+  controllers: [AppController, HealthController, CardController],
+  providers: [AppService, DatabaseService, CardService],
 })
 export class AppModule {}

--- a/backend/src/card.controller.ts
+++ b/backend/src/card.controller.ts
@@ -1,0 +1,57 @@
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { CardService } from './card.service';
+
+@Controller('cards')
+export class CardController {
+  constructor(private readonly cards: CardService) {}
+
+  @Post()
+  create(@Body() body: any) {
+    const { userId, title, description, element, weight } = body;
+    return this.cards.createCard(userId, title, description, element, weight);
+  }
+
+  @Get()
+  list() {
+    return this.cards.getCards();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string) {
+    return this.cards.getCard(Number(id));
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() body: any) {
+    const { userId, ...fields } = body;
+    return this.cards.updateCard(Number(id), userId, fields);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string, @Body('userId') userId: number) {
+    return this.cards.deleteCard(Number(id), userId);
+  }
+
+  @Post(':id/split')
+  split(@Param('id') id: string, @Body() body: any) {
+    const { userId, titles } = body;
+    return this.cards.splitCard(Number(id), userId, titles);
+  }
+
+  @Post(':id/refuse')
+  refuse(@Param('id') id: string, @Body('userId') userId: number) {
+    return this.cards.refuseCard(Number(id), userId);
+  }
+
+  @Post(':id/element')
+  setElement(@Param('id') id: string, @Body() body: any) {
+    const { userId, element } = body;
+    return this.cards.assignElement(Number(id), userId, element);
+  }
+
+  @Post(':id/weight')
+  setWeight(@Param('id') id: string, @Body() body: any) {
+    const { userId, weight } = body;
+    return this.cards.assignWeight(Number(id), userId, weight);
+  }
+}

--- a/backend/src/card.service.ts
+++ b/backend/src/card.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from './database.service';
+
+@Injectable()
+export class CardService {
+  constructor(private readonly db: DatabaseService) {}
+
+  private async log(cardId: number, userId: number, action: string, details: any) {
+    await this.db.query(
+      'INSERT INTO card_logs (card_id, user_id, action, details) VALUES ($1, $2, $3, $4)',
+      [cardId, userId, action, JSON.stringify(details)]
+    );
+  }
+
+  async createCard(userId: number, title: string, description?: string, element?: string, weight?: number) {
+    const result = await this.db.query(
+      `INSERT INTO cards (title, description, element, weight, created_by) VALUES ($1,$2,$3,$4,$5) RETURNING *`,
+      [title, description, element, weight, userId]
+    );
+    const card = result.rows[0];
+    await this.log(card.id, userId, 'create', { title, description, element, weight });
+    return card;
+  }
+
+  async getCards() {
+    const result = await this.db.query('SELECT * FROM cards ORDER BY id');
+    return result.rows;
+  }
+
+  async getCard(id: number) {
+    const result = await this.db.query('SELECT * FROM cards WHERE id = $1', [id]);
+    return result.rows[0];
+  }
+
+  async updateCard(id: number, userId: number, fields: any) {
+    const updates = [] as string[];
+    const params = [] as any[];
+    let idx = 1;
+    for (const key of ['title', 'description', 'element', 'weight', 'status', 'parent_id']) {
+      if (fields[key] !== undefined) {
+        updates.push(`${key} = $${idx}`);
+        params.push(fields[key]);
+        idx++;
+      }
+    }
+    if (updates.length === 0) return this.getCard(id);
+    params.push(id);
+    await this.db.query(`UPDATE cards SET ${updates.join(', ')} WHERE id = $${idx}`, params);
+    await this.log(id, userId, 'update', fields);
+    return this.getCard(id);
+  }
+
+  async deleteCard(id: number, userId: number) {
+    await this.db.query('DELETE FROM cards WHERE id = $1', [id]);
+    await this.log(id, userId, 'delete', {});
+  }
+
+  async splitCard(id: number, userId: number, titles: string[]) {
+    const created = [] as any[];
+    for (const title of titles) {
+      const res = await this.db.query(
+        `INSERT INTO cards (title, parent_id, created_by) VALUES ($1,$2,$3) RETURNING *`,
+        [title, id, userId]
+      );
+      created.push(res.rows[0]);
+      await this.log(res.rows[0].id, userId, 'create_split', { parentId: id });
+    }
+    await this.log(id, userId, 'split', { count: titles.length });
+    return created;
+  }
+
+  async refuseCard(id: number, userId: number) {
+    await this.db.query(`UPDATE cards SET status = 'rejected' WHERE id = $1`, [id]);
+    await this.log(id, userId, 'refuse', {});
+    return this.getCard(id);
+  }
+
+  async assignElement(id: number, userId: number, element: string) {
+    await this.db.query(`UPDATE cards SET element = $1 WHERE id = $2`, [element, id]);
+    await this.log(id, userId, 'assign_element', { element });
+    return this.getCard(id);
+  }
+
+  async assignWeight(id: number, userId: number, weight: number) {
+    await this.db.query(`UPDATE cards SET weight = $1 WHERE id = $2`, [weight, id]);
+    await this.log(id, userId, 'assign_weight', { weight });
+    return this.getCard(id);
+  }
+}

--- a/backend/src/database.service.ts
+++ b/backend/src/database.service.ts
@@ -9,10 +9,10 @@ export class DatabaseService implements OnModuleDestroy {
     this.pool = new Pool({ connectionString: process.env.DATABASE_URL });
   }
 
-  async query(sql: string) {
+  async query(sql: string, params?: any[]) {
     const client = await this.pool.connect();
     try {
-      return await client.query(sql);
+      return await client.query(sql, params);
     } finally {
       client.release();
     }

--- a/db/init/01_create_tables.sql
+++ b/db/init/01_create_tables.sql
@@ -4,3 +4,24 @@ CREATE TABLE IF NOT EXISTS users (
     display_name TEXT,
     created_at TIMESTAMPTZ DEFAULT now()
 );
+
+CREATE TABLE IF NOT EXISTS cards (
+    id SERIAL PRIMARY KEY,
+    title TEXT NOT NULL,
+    description TEXT,
+    element TEXT,
+    weight INT,
+    status TEXT DEFAULT 'unprocessed',
+    parent_id INT REFERENCES cards(id),
+    created_by INT REFERENCES users(id),
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS card_logs (
+    id SERIAL PRIMARY KEY,
+    card_id INT REFERENCES cards(id),
+    user_id INT REFERENCES users(id),
+    action TEXT NOT NULL,
+    details JSONB,
+    created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/db/init/02_seed.sql
+++ b/db/init/02_seed.sql
@@ -1,1 +1,4 @@
 INSERT INTO users (email, display_name) VALUES ('test@example.com', 'Tester');
+
+INSERT INTO cards (title, description, created_by)
+VALUES ('Sample card', 'This is a seed card', 1);


### PR DESCRIPTION
## Summary
- implement DB schema for cards and action logs
- create Card service & controller with CRUD and card operations
- log all card actions
- expose card API via AppModule

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686844d98dd083219d76de8963a18594