### PR TITLE
Fix Expo web start

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,10 @@ docker compose up --build
 
 This brings up the NestJS API, the Expo client, PostgreSQL and Redis.
 The client is served on [http://localhost:3000](http://localhost:3000) and the API on [http://localhost:4000](http://localhost:4000).
+
+When running the client outside of Docker, make sure the web dependencies are installed:
+
+```bash
+cd client
+npx expo install react-native-web@~0.19.6 react-dom@18.2.0 @expo/webpack-config@^19.0.0
+```

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,9 @@
     "expo": "^49.0.0",
     "react": "18.2.0",
     "react-native": "0.72.4",
+    "react-native-web": "~0.19.6",
+    "react-dom": "18.2.0",
+    "@expo/webpack-config": "^19.0.0",
     "typescript": "^5.1.3",
     "@types/react": "~18.2.14"
   }


### PR DESCRIPTION
## Summary
- add Expo web dependencies
- document how to install these packages when running the client manually

## Testing
- `npm run build` in `backend`
- `./scripts/test_health.sh` *(fails: API did not become healthy)*

------
https://chatgpt.com/codex/tasks/task_e_68684fb1a14483219454a498da9cf6f3