### PR TITLE
Implement login and cards list

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,9 +5,11 @@ import { HealthController } from './health.controller';
 import { DatabaseService } from './database.service';
 import { CardController } from './card.controller';
 import { CardService } from './card.service';
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
 
 @Module({
-  controllers: [AppController, HealthController, CardController],
-  providers: [AppService, DatabaseService, CardService],
+  controllers: [AppController, HealthController, CardController, UserController],
+  providers: [AppService, DatabaseService, CardService, UserService],
 })
 export class AppModule {}

--- a/backend/src/user.controller.ts
+++ b/backend/src/user.controller.ts
@@ -1,0 +1,12 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { UserService } from './user.service';
+
+@Controller('users')
+export class UserController {
+  constructor(private readonly users: UserService) {}
+
+  @Post('login')
+  login(@Body('email') email: string) {
+    return this.users.findOrCreateByEmail(email);
+  }
+}

--- a/backend/src/user.service.ts
+++ b/backend/src/user.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from './database.service';
+
+@Injectable()
+export class UserService {
+  constructor(private readonly db: DatabaseService) {}
+
+  async findOrCreateByEmail(email: string) {
+    const result = await this.db.query('SELECT * FROM users WHERE email = $1', [email]);
+    if (result.rows.length > 0) {
+      return result.rows[0];
+    }
+    const insert = await this.db.query('INSERT INTO users (email) VALUES ($1) RETURNING *', [email]);
+    return insert.rows[0];
+  }
+}

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -2,13 +2,14 @@ import React, { useState } from 'react';
 import LoginScreen from './screens/LoginScreen';
 import HomeScreen from './screens/HomeScreen';
 import SubmitCardScreen from './screens/SubmitCardScreen';
+import CardsListScreen from './screens/CardsListScreen';
 
 export default function App() {
   const [user, setUser] = useState<{ email: string; id: number } | null>(null);
-  const [screen, setScreen] = useState<'login' | 'home' | 'submit'>('login');
+  const [screen, setScreen] = useState<'login' | 'home' | 'submit' | 'cards'>('login');
 
-  function handleLogin(email: string) {
-    setUser({ email, id: 1 });
+  function handleLogin(u: { email: string; id: number }) {
+    setUser(u);
     setScreen('home');
   }
 
@@ -20,5 +21,15 @@ export default function App() {
     return <SubmitCardScreen userId={user.id} onDone={() => setScreen('home')} />;
   }
 
-  return <HomeScreen email={user.email} onSubmitCard={() => setScreen('submit')} />;
+  if (screen === 'cards') {
+    return <CardsListScreen onBack={() => setScreen('home')} />;
+  }
+
+  return (
+    <HomeScreen
+      email={user.email}
+      onSubmitCard={() => setScreen('submit')}
+      onShowCards={() => setScreen('cards')}
+    />
+  );
 }

--- a/client/screens/CardsListScreen.tsx
+++ b/client/screens/CardsListScreen.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, RefreshControl, Button } from 'react-native';
+
+export interface Card {
+  id: number;
+  title: string;
+  description?: string;
+}
+
+export default function CardsListScreen({ onBack }: { onBack: () => void }) {
+  const [cards, setCards] = useState<Card[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  async function loadCards() {
+    setRefreshing(true);
+    try {
+      const res = await fetch('http://localhost:4000/cards');
+      const data = await res.json();
+      setCards(data);
+    } catch (err) {
+      console.error('Failed to load cards');
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  useEffect(() => {
+    loadCards();
+  }, []);
+
+  return (
+    <View style={{ flex: 1, padding: 20 }}>
+      <Button title="Back" onPress={onBack} />
+      <FlatList
+        style={{ marginTop: 10 }}
+        data={cards}
+        keyExtractor={(item) => item.id.toString()}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={loadCards} />}
+        renderItem={({ item }) => (
+          <View style={{ padding: 12, borderBottomWidth: 1 }}>
+            <Text style={{ fontWeight: 'bold' }}>{item.title}</Text>
+            {item.description ? <Text>{item.description}</Text> : null}
+          </View>
+        )}
+      />
+    </View>
+  );
+}

--- a/client/screens/HomeScreen.tsx
+++ b/client/screens/HomeScreen.tsx
@@ -1,11 +1,21 @@
 import React from 'react';
 import { View, Text, Button } from 'react-native';
 
-export default function HomeScreen({ email, onSubmitCard }: { email: string; onSubmitCard: () => void }) {
+export default function HomeScreen({
+  email,
+  onSubmitCard,
+  onShowCards,
+}: {
+  email: string;
+  onSubmitCard: () => void;
+  onShowCards: () => void;
+}) {
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <Text style={{ fontSize: 20, marginBottom: 20 }}>Welcome {email}</Text>
       <Button title="Submit Card" onPress={onSubmitCard} />
+      <View style={{ height: 12 }} />
+      <Button title="View Cards" onPress={onShowCards} />
     </View>
   );
 }

--- a/client/screens/LoginScreen.tsx
+++ b/client/screens/LoginScreen.tsx
@@ -1,8 +1,23 @@
 import React, { useState } from 'react';
-import { View, TextInput, Button, Text } from 'react-native';
+import { View, TextInput, Button, Text, Alert } from 'react-native';
 
-export default function LoginScreen({ onLogin }: { onLogin: (email: string) => void }) {
+export default function LoginScreen({ onLogin }: { onLogin: (user: { id: number; email: string }) => void }) {
   const [email, setEmail] = useState('');
+
+  async function handleLogin() {
+    try {
+      const res = await fetch('http://localhost:4000/users/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+      onLogin(data);
+    } catch (err) {
+      Alert.alert('Error', 'Failed to login');
+    }
+  }
+
   return (
     <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
       <Text style={{ fontSize: 24, marginBottom: 20 }}>Login</Text>
@@ -13,7 +28,7 @@ export default function LoginScreen({ onLogin }: { onLogin: (email: string) => v
         onChangeText={setEmail}
         style={{ borderWidth: 1, marginBottom: 20, padding: 8 }}
       />
-      <Button title="Login" onPress={() => onLogin(email)} />
+      <Button title="Login" onPress={handleLogin} />
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- allow users to login via new `/users/login` endpoint
- implement UserService and wire into Nest app
- show cards list in a new React Native screen
- hook login and navigation logic up in the client

## Testing
- `npm run build` in `backend`
- `npm run build` in `client`
- `./scripts/test_health.sh` *(fails: API did not become healthy)*

------
https://chatgpt.com/codex/tasks/task_e_6868660c6fa48321858fd15e84d42895