### PR TITLE
Add database manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Default set: **1 – 2 – 3 – 5 – 8 – 13 – 21�
 | **API**           | Node.js (NestJS)                 |
 | **DB**            | PostgreSQL (Prisma ORM)          |
 | **Cache/Pub‑Sub** | Redis                            |
+| **DB Admin**      | PgAdmin                          |
 | **Auth**          | JWT + email magic‑link           |
 | **Containers**    | Docker Compose                   |
 
@@ -115,6 +116,10 @@ services:
     volumes: ["db_data:/var/lib/postgresql/data"]
   redis:
     image: redis:7-alpine
+  db-admin:
+    image: dpage/pgadmin4
+    ports: ["8080:80"]
+    depends_on: [db]
 volumes:
   db_data:
 ```
@@ -156,8 +161,11 @@ A `docker-compose.yml` is provided to spin up all services:
 docker compose up --build
 ```
 
-This brings up the NestJS API, the Expo client, PostgreSQL and Redis.
+This brings up the NestJS API, the Expo client, PostgreSQL, Redis and the PgAdmin
+database manager.
 The client is served on [http://localhost:3000](http://localhost:3000) and the API on [http://localhost:4000](http://localhost:4000).
+PgAdmin is reachable on [http://localhost:8080](http://localhost:8080).
+Use **admin@example.com** / **adminpass** to log in.
 
 
 When running the client outside of Docker, make sure the web dependencies are installed:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,5 +30,14 @@ services:
       - ./db/init:/docker-entrypoint-initdb.d:ro
   redis:
     image: redis:7-alpine
+  db-admin:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: adminpass
+    ports:
+      - "8080:80"
+    depends_on:
+      - db
 volumes:
   db_data:


### PR DESCRIPTION
## Summary
- add pgadmin service to docker compose
- document db-admin service in README

## Testing
- `npm run build` in backend
- `./scripts/test_health.sh` *(fails: API did not become healthy)*

------
https://chatgpt.com/codex/tasks/task_e_6868665c44f88321aad4835b04038358