### PR TITLE
Add dependency cache for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,20 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
+      - name: Cache backend dependencies
+        uses: actions/cache@v3
+        with:
+          path: backend/node_modules
+          key: backend-node-${{ runner.os }}-${{ hashFiles('backend/package.json') }}
+          restore-keys: |
+            backend-node-${{ runner.os }}-
+      - name: Cache client dependencies
+        uses: actions/cache@v3
+        with:
+          path: client/node_modules
+          key: client-node-${{ runner.os }}-${{ hashFiles('client/package.json') }}
+          restore-keys: |
+            client-node-${{ runner.os }}-
       - name: Install and build backend
         working-directory: backend
         run: |


### PR DESCRIPTION
## Summary
- cache `backend` and `client` node modules in workflow

## Testing
- `npm run build` in `backend`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68686743bcfc8321a0918a959aff8d29