### PR TITLE
Enable CORS in development

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,6 +3,9 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  if (process.env.NODE_ENV === 'development') {
+    app.enableCors();
+  }
   await app.listen(4000);
 }
 


### PR DESCRIPTION
## Summary
- enable CORS when `NODE_ENV` is `development`

## Testing
- `npm run build` in `backend`
- `npm run build` in `client`
- `./scripts/test_health.sh` *(fails: API did not become healthy)*

------
https://chatgpt.com/codex/tasks/task_e_68686980b10483219ee003b7aff63787