### PR TITLE
Add websocket poker room proof of concept

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,9 +7,16 @@ import { CardController } from './card.controller';
 import { CardService } from './card.service';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
+import { ScoreController } from './score.controller';
 
 @Module({
-  controllers: [AppController, HealthController, CardController, UserController],
+  controllers: [
+    AppController,
+    HealthController,
+    CardController,
+    UserController,
+    ScoreController,
+  ],
   providers: [AppService, DatabaseService, CardService, UserService],
 })
 export class AppModule {}

--- a/backend/src/card.service.ts
+++ b/backend/src/card.service.ts
@@ -94,4 +94,11 @@ export class CardService {
     await this.log(id, userId, 'assign_weight', { weight });
     return this.getCard(id);
   }
+
+  /**
+   * Public helper used outside HTTP controllers to log arbitrary card actions.
+   */
+  async recordAction(cardId: number, userId: number, action: string, details: any) {
+    await this.log(cardId, userId, action, details);
+  }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,11 +1,56 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { initRoom, getRoomState } from './room.state';
+import { CardService } from './card.service';
+
+const { WebSocketServer } = require('../../client/node_modules/ws');
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   if (process.env.NODE_ENV === 'development') {
     app.enableCors();
   }
+  await initRoom(app.get(CardService));
+
+  const server = app.getHttpServer();
+  const wss = new WebSocketServer({ noServer: true });
+
+  wss.on('connection', (ws: any) => {
+    ws.on('message', async (data: Buffer) => {
+      const msg = JSON.parse(data.toString());
+      const room = getRoomState();
+      if (!room) return;
+      if (msg.type === 'join') {
+        ws.userId = msg.userId;
+        ws.send(JSON.stringify({ type: 'state', ...room.getState() }));
+      } else if (msg.type === 'draw') {
+        const card = room.drawCard();
+        if (card) {
+          await room.cardService.recordAction(card.id, msg.userId, 'draw', {});
+          const payload = JSON.stringify({ type: 'card', card, deckCount: room.deck.length });
+          wss.clients.forEach((c: any) => c.send(payload));
+        }
+      } else if (msg.type === 'vote') {
+        room.vote(msg.cardId, msg.userId, msg.value);
+        await room.cardService.recordAction(msg.cardId, msg.userId, 'vote', { value: msg.value });
+        const payload = JSON.stringify({ type: 'vote', cardId: msg.cardId, userId: msg.userId, value: msg.value });
+        wss.clients.forEach((c: any) => c.send(payload));
+      } else if (msg.type === 'end') {
+        room.endSession();
+        const payload = JSON.stringify({ type: 'end' });
+        wss.clients.forEach((c: any) => c.send(payload));
+      }
+    });
+  });
+
+  server.on('upgrade', (req: any, socket: any, head: any) => {
+    if (req.url === '/room') {
+      wss.handleUpgrade(req, socket, head, (ws: any) => {
+        wss.emit('connection', ws, req);
+      });
+    }
+  });
+
   await app.listen(4000);
 }
 

--- a/backend/src/room.state.ts
+++ b/backend/src/room.state.ts
@@ -1,0 +1,56 @@
+import { CardService } from './card.service';
+
+export interface TableCard {
+  card: any;
+  votes: Record<number, number>;
+}
+
+export class RoomState {
+  deck: any[] = [];
+  table: TableCard[] = [];
+  scores: Record<number, number> = {};
+
+  constructor(public cardService: CardService) {}
+
+  async init() {
+    const cards = await this.cardService.getCards();
+    this.deck = cards.filter((c) => c.element);
+  }
+
+  drawCard() {
+    const card = this.deck.shift();
+    if (!card) return null;
+    this.table.push({ card, votes: {} });
+    return card;
+  }
+
+  vote(cardId: number, userId: number, value: number) {
+    const tc = this.table.find((t) => t.card.id === cardId);
+    if (!tc) return;
+    tc.votes[userId] = value;
+    this.scores[userId] = (this.scores[userId] || 0) + value;
+  }
+
+  endSession() {
+    this.table = [];
+  }
+
+  getScores() {
+    return this.scores;
+  }
+
+  getState() {
+    return { deckCount: this.deck.length, table: this.table };
+  }
+}
+
+let state: RoomState;
+
+export async function initRoom(cardService: CardService) {
+  state = new RoomState(cardService);
+  await state.init();
+}
+
+export function getRoomState() {
+  return state;
+}

--- a/backend/src/score.controller.ts
+++ b/backend/src/score.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get } from '@nestjs/common';
+import { getRoomState } from './room.state';
+
+@Controller('scores')
+export class ScoreController {
+  @Get()
+  getScores() {
+    const state = getRoomState();
+    if (!state) return [];
+    const scores = state.getScores();
+    return Object.entries(scores).map(([user_id, points]) => ({
+      user_id: Number(user_id),
+      points,
+    }));
+  }
+}

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -4,10 +4,12 @@ import HomeScreen from './screens/HomeScreen';
 import SubmitCardScreen from './screens/SubmitCardScreen';
 import CardsListScreen from './screens/CardsListScreen';
 import CardLogsScreen from './screens/CardLogsScreen';
+import PokerRoomScreen from './screens/PokerRoomScreen';
+import ScoresScreen from './screens/ScoresScreen';
 
 export default function App() {
   const [user, setUser] = useState<{ email: string; id: number } | null>(null);
-  const [screen, setScreen] = useState<'login' | 'home' | 'submit' | 'cards' | 'logs'>('login');
+  const [screen, setScreen] = useState<'login' | 'home' | 'submit' | 'cards' | 'logs' | 'room' | 'scores'>('login');
   const [logCardId, setLogCardId] = useState<number | null>(null);
 
   function handleLogin(u: { email: string; id: number }) {
@@ -44,11 +46,21 @@ export default function App() {
     );
   }
 
+  if (screen === 'room') {
+    return <PokerRoomScreen userId={user.id} onBack={() => setScreen('home')} />;
+  }
+
+  if (screen === 'scores') {
+    return <ScoresScreen onBack={() => setScreen('home')} />;
+  }
+
   return (
     <HomeScreen
       email={user.email}
       onSubmitCard={() => setScreen('submit')}
       onShowCards={() => setScreen('cards')}
+      onEnterRoom={() => setScreen('room')}
+      onShowScores={() => setScreen('scores')}
     />
   );
 }

--- a/client/screens/HomeScreen.tsx
+++ b/client/screens/HomeScreen.tsx
@@ -6,10 +6,14 @@ export default function HomeScreen({
   email,
   onSubmitCard,
   onShowCards,
+  onEnterRoom,
+  onShowScores,
 }: {
   email: string;
   onSubmitCard: () => void;
   onShowCards: () => void;
+  onEnterRoom: () => void;
+  onShowScores: () => void;
 }) {
   return (
     <View style={styles.container}>
@@ -17,6 +21,10 @@ export default function HomeScreen({
       <Button title="Submit Card" onPress={onSubmitCard} color={theme.accent} />
       <View style={{ height: 12 }} />
       <Button title="View Cards" onPress={onShowCards} color={theme.accent} />
+      <View style={{ height: 12 }} />
+      <Button title="Enter Room" onPress={onEnterRoom} color={theme.accent} />
+      <View style={{ height: 12 }} />
+      <Button title="Scores" onPress={onShowScores} color={theme.accent} />
     </View>
   );
 }

--- a/client/screens/PokerRoomScreen.tsx
+++ b/client/screens/PokerRoomScreen.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
+import { theme } from '../theme';
+
+const FIB = [1, 2, 3, 5, 8, 13];
+
+export default function PokerRoomScreen({ userId, onBack }: { userId: number; onBack: () => void }) {
+  const [table, setTable] = useState<any[]>([]);
+  const [deckCount, setDeckCount] = useState(0);
+  const [ws, setWs] = useState<WebSocket | null>(null);
+
+  useEffect(() => {
+    const socket = new WebSocket('ws://localhost:4000/room');
+    socket.onopen = () => {
+      socket.send(JSON.stringify({ type: 'join', userId }));
+    };
+    socket.onmessage = (ev) => {
+      const msg = JSON.parse(ev.data);
+      if (msg.type === 'state') {
+        setTable(msg.table);
+        setDeckCount(msg.deckCount);
+      } else if (msg.type === 'card') {
+        setTable((t) => [...t, { card: msg.card, votes: {} }]);
+        setDeckCount(msg.deckCount);
+      } else if (msg.type === 'vote') {
+        setTable((t) =>
+          t.map((tc) =>
+            tc.card.id === msg.cardId ? { ...tc, votes: { ...tc.votes, [msg.userId]: msg.value } } : tc
+          )
+        );
+      } else if (msg.type === 'end') {
+        setTable([]);
+      }
+    };
+    setWs(socket);
+    return () => {
+      socket.close();
+    };
+  }, [userId]);
+
+  function drawCard() {
+    ws?.send(JSON.stringify({ type: 'draw', userId }));
+  }
+
+  function castVote(cardId: number, value: number) {
+    ws?.send(JSON.stringify({ type: 'vote', cardId, userId, value }));
+  }
+
+  return (
+    <View style={styles.container}>
+      <Button title="Back" onPress={onBack} color={theme.accent} />
+      <Text style={styles.text}>Deck: {deckCount}</Text>
+      <Button title="Draw Card" onPress={drawCard} color={theme.accent} />
+      <FlatList
+        style={{ marginTop: 20 }}
+        data={table}
+        keyExtractor={(i) => i.card.id.toString()}
+        renderItem={({ item }) => (
+          <View style={styles.card}>
+            <Text style={styles.title}>{item.card.title}</Text>
+            <View style={styles.row}>
+              {FIB.map((f) => (
+                <TouchableOpacity key={f} onPress={() => castVote(item.card.id, f)} style={styles.vote}>
+                  <Text style={styles.voteText}>{f}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+            <Text style={styles.text}>Votes: {Object.values(item.votes).join(', ')}</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20, backgroundColor: theme.background },
+  text: { color: theme.text, marginBottom: 10 },
+  card: { padding: 12, borderBottomWidth: 1, borderColor: theme.accent },
+  row: { flexDirection: 'row', marginTop: 10 },
+  vote: { backgroundColor: theme.card, padding: 6, marginRight: 6 },
+  voteText: { color: theme.text },
+  title: { color: theme.text, fontWeight: 'bold' },
+});

--- a/client/screens/ScoresScreen.tsx
+++ b/client/screens/ScoresScreen.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, FlatList, StyleSheet } from 'react-native';
+import { API_URL } from '../api';
+import { theme } from '../theme';
+
+interface Score { user_id: number; points: number }
+
+export default function ScoresScreen({ onBack }: { onBack: () => void }) {
+  const [scores, setScores] = useState<Score[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/scores`)
+      .then((res) => res.json())
+      .then(setScores)
+      .catch(() => {});
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Button title="Back" onPress={onBack} color={theme.accent} />
+      <FlatList
+        style={{ marginTop: 10 }}
+        data={scores}
+        keyExtractor={(i) => i.user_id.toString()}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <Text style={styles.text}>User {item.user_id}: {item.points}</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20, backgroundColor: theme.background },
+  row: { padding: 12, borderBottomWidth: 1, borderColor: theme.accent },
+  text: { color: theme.text },
+});


### PR DESCRIPTION
## Summary
- create in-memory poker room with websocket server
- expose score summary endpoint
- add poker room and scores screens
- wire navigation from home page

## Testing
- `npm run build` in `backend`
- `npm run build` in `client`
- `./scripts/test_health.sh` *(fails: API not running)*

------
https://chatgpt.com/codex/tasks/task_e_686921bcc1108321a49643f45f9765cb