### PR TITLE
Fix backend WebSocket import

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "@nestjs/platform-express": "^10.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
-    "pg": "^8.11.1"
+    "pg": "^8.11.1",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "ts-node-dev": "^2.0.0",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,8 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { initRoom, getRoomState } from './room.state';
 import { CardService } from './card.service';
-
-const { WebSocketServer } = require('../../client/node_modules/ws');
+import { WebSocketServer } from 'ws';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
## Summary
- fix module path for WebSocketServer
- declare `ws` package in backend dependencies

## Testing
- `npm run build`
- `./scripts/test_health.sh` *(fails: API did not become healthy)*

------
https://chatgpt.com/codex/tasks/task_e_6869275cabc48321968dcdb10fd1697c