### PR TITLE
Add KPI summary endpoint and scores dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Vote(id, session_id, card_id, participant_id, value, created_at)
 | POST   | /sessions/\:id/join   | Join session                  |
 | POST   | /sessions/\:id/vote   | Cast vote                     |
 | POST   | /sessions/\:id/reveal | Reveal votes                  |
+| GET    | /users                | List users                    |
 | GET    | /kpi/summary          | Aggregate KPIs                |
 
 ### WebSocket Events

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { CardService } from './card.service';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 import { ScoreController } from './score.controller';
+import { KpiController } from './kpi.controller';
 
 @Module({
   controllers: [
@@ -16,6 +17,7 @@ import { ScoreController } from './score.controller';
     CardController,
     UserController,
     ScoreController,
+    KpiController,
   ],
   providers: [AppService, DatabaseService, CardService, UserService],
 })

--- a/backend/src/kpi.controller.ts
+++ b/backend/src/kpi.controller.ts
@@ -1,0 +1,57 @@
+import { Controller, Get } from '@nestjs/common';
+import { DatabaseService } from './database.service';
+import { getRoomState } from './room.state';
+
+@Controller('kpi')
+export class KpiController {
+  constructor(private readonly db: DatabaseService) {}
+
+  @Get('summary')
+  async summary() {
+    const usersRes = await this.db.query(
+      'SELECT id, email, display_name FROM users ORDER BY id',
+    );
+
+    const scores = getRoomState()?.getScores() || {};
+
+    const userStatsRes = await this.db.query(
+      `SELECT u.id,
+              COUNT(CASE WHEN cl.action = 'create' THEN 1 END) AS cards_created,
+              COUNT(CASE WHEN cl.action = 'vote' THEN 1 END) AS votes
+         FROM users u
+         LEFT JOIN card_logs cl ON cl.user_id = u.id
+        GROUP BY u.id
+        ORDER BY u.id`,
+    );
+
+    const totalCardsRes = await this.db.query('SELECT COUNT(*) FROM cards');
+    const totalVotesRes = await this.db.query(
+      "SELECT COUNT(*) FROM card_logs WHERE action = 'vote'",
+    );
+
+    const statsMap: Record<number, any> = {};
+    for (const row of userStatsRes.rows) {
+      statsMap[row.id] = {
+        cards_created: Number(row.cards_created),
+        votes: Number(row.votes),
+      };
+    }
+
+    const users = usersRes.rows.map((u: any) => ({
+      id: u.id,
+      email: u.email,
+      display_name: u.display_name,
+      score: scores[u.id] || 0,
+      cards_created: statsMap[u.id]?.cards_created || 0,
+      votes: statsMap[u.id]?.votes || 0,
+    }));
+
+    return {
+      team: {
+        total_cards: Number(totalCardsRes.rows[0].count),
+        total_votes: Number(totalVotesRes.rows[0].count),
+      },
+      users,
+    };
+  }
+}

--- a/backend/src/user.controller.ts
+++ b/backend/src/user.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { UserService } from './user.service';
 
 @Controller('users')
@@ -8,5 +8,10 @@ export class UserController {
   @Post('login')
   login(@Body('email') email: string) {
     return this.users.findOrCreateByEmail(email);
+  }
+
+  @Get()
+  list() {
+    return this.users.getAllUsers();
   }
 }

--- a/backend/src/user.service.ts
+++ b/backend/src/user.service.ts
@@ -13,4 +13,9 @@ export class UserService {
     const insert = await this.db.query('INSERT INTO users (email) VALUES ($1) RETURNING *', [email]);
     return insert.rows[0];
   }
+
+  async getAllUsers() {
+    const result = await this.db.query('SELECT * FROM users ORDER BY id');
+    return result.rows;
+  }
 }

--- a/client/screens/ScoresScreen.tsx
+++ b/client/screens/ScoresScreen.tsx
@@ -3,28 +3,49 @@ import { View, Text, Button, FlatList, StyleSheet } from 'react-native';
 import { API_URL } from '../api';
 import { theme } from '../theme';
 
-interface Score { user_id: number; points: number }
+interface UserKpi {
+  id: number;
+  email: string;
+  display_name: string | null;
+  score: number;
+  cards_created: number;
+  votes: number;
+}
+
+interface Summary {
+  team: { total_cards: number; total_votes: number };
+  users: UserKpi[];
+}
 
 export default function ScoresScreen({ onBack }: { onBack: () => void }) {
-  const [scores, setScores] = useState<Score[]>([]);
+  const [summary, setSummary] = useState<Summary | null>(null);
 
   useEffect(() => {
-    fetch(`${API_URL}/scores`)
+    fetch(`${API_URL}/kpi/summary`)
       .then((res) => res.json())
-      .then(setScores)
+      .then(setSummary)
       .catch(() => {});
   }, []);
 
   return (
     <View style={styles.container}>
       <Button title="Back" onPress={onBack} color={theme.accent} />
+      {summary && (
+        <View style={styles.row}>
+          <Text style={styles.text}>
+            Team Cards: {summary.team.total_cards} | Votes: {summary.team.total_votes}
+          </Text>
+        </View>
+      )}
       <FlatList
         style={{ marginTop: 10 }}
-        data={scores}
-        keyExtractor={(i) => i.user_id.toString()}
+        data={summary?.users || []}
+        keyExtractor={(i) => i.id.toString()}
         renderItem={({ item }) => (
           <View style={styles.row}>
-            <Text style={styles.text}>User {item.user_id}: {item.points}</Text>
+            <Text style={styles.text}>
+              {item.email} - Score {item.score} - Created {item.cards_created} - Votes {item.votes}
+            </Text>
           </View>
         )}
       />


### PR DESCRIPTION
## Summary
- expose `/users` list and new `/kpi/summary` endpoint
- show team metrics & user KPIs on scores screen
- document new endpoint in README

## Testing
- `npm run build` in `backend`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_686a56a0cc74832197ce52670ebda5b8