### PR TITLE
Add per-user Fibonacci selection

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -8,11 +8,14 @@ import PokerRoomScreen from './screens/PokerRoomScreen';
 import ScoresScreen from './screens/ScoresScreen';
 
 export default function App() {
-  const [user, setUser] = useState<{ email: string; id: number } | null>(null);
+  const [user, setUser] = useState<
+    | { email: string; id: number; fibonacci: number[] }
+    | null
+  >(null);
   const [screen, setScreen] = useState<'login' | 'home' | 'submit' | 'cards' | 'logs' | 'room' | 'scores'>('login');
   const [logCardId, setLogCardId] = useState<number | null>(null);
 
-  function handleLogin(u: { email: string; id: number }) {
+  function handleLogin(u: { email: string; id: number; fibonacci: number[] }) {
     setUser(u);
     setScreen('home');
   }
@@ -47,7 +50,13 @@ export default function App() {
   }
 
   if (screen === 'room') {
-    return <PokerRoomScreen userId={user.id} onBack={() => setScreen('home')} />;
+    return (
+      <PokerRoomScreen
+        userId={user.id}
+        fibonacci={user.fibonacci}
+        onBack={() => setScreen('home')}
+      />
+    );
   }
 
   if (screen === 'scores') {

--- a/client/screens/LoginScreen.tsx
+++ b/client/screens/LoginScreen.tsx
@@ -3,7 +3,11 @@ import { View, TextInput, Button, Text, Alert, StyleSheet } from 'react-native';
 import { API_URL } from '../api';
 import { theme } from '../theme';
 
-export default function LoginScreen({ onLogin }: { onLogin: (user: { id: number; email: string }) => void }) {
+export default function LoginScreen({
+  onLogin,
+}: {
+  onLogin: (user: { id: number; email: string; fibonacci: number[] }) => void;
+}) {
   const [email, setEmail] = useState('');
 
   async function handleLogin() {

--- a/client/screens/PokerRoomScreen.tsx
+++ b/client/screens/PokerRoomScreen.tsx
@@ -2,9 +2,15 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, Button, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
 import { theme } from '../theme';
 
-const FIB = [1, 2, 3, 5, 8, 13];
-
-export default function PokerRoomScreen({ userId, onBack }: { userId: number; onBack: () => void }) {
+export default function PokerRoomScreen({
+  userId,
+  fibonacci,
+  onBack,
+}: {
+  userId: number;
+  fibonacci: number[];
+  onBack: () => void;
+}) {
   const [table, setTable] = useState<any[]>([]);
   const [deckCount, setDeckCount] = useState(0);
   const [ws, setWs] = useState<WebSocket | null>(null);
@@ -59,7 +65,7 @@ export default function PokerRoomScreen({ userId, onBack }: { userId: number; on
           <View style={styles.card}>
             <Text style={styles.title}>{item.card.title}</Text>
             <View style={styles.row}>
-              {FIB.map((f) => (
+              {fibonacci.map((f) => (
                 <TouchableOpacity key={f} onPress={() => castVote(item.card.id, f)} style={styles.vote}>
                   <Text style={styles.voteText}>{f}</Text>
                 </TouchableOpacity>

--- a/db/init/01_create_tables.sql
+++ b/db/init/01_create_tables.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS users (
     id SERIAL PRIMARY KEY,
     email TEXT NOT NULL,
     display_name TEXT,
+    fibonacci INT[] DEFAULT '{1,2,3,5,8,13}',
     created_at TIMESTAMPTZ DEFAULT now()
 );
 

--- a/db/init/02_seed.sql
+++ b/db/init/02_seed.sql
@@ -1,4 +1,5 @@
-INSERT INTO users (email, display_name) VALUES ('test@example.com', 'Tester');
+INSERT INTO users (email, display_name, fibonacci)
+VALUES ('test@example.com', 'Tester', '{1,2,3,5,8,13}');
 
 INSERT INTO cards (title, description, created_by)
 VALUES ('Sample card', 'This is a seed card', 1);


### PR DESCRIPTION
## Summary
- allow users to have their own Fibonacci sequence by adding a `fibonacci` column
- expose Fibonacci values on login
- display user Fibonacci values in Poker Room

## Testing
- `npm run build` in `backend`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_686b912ed8bc832187562dbd7e94c2df