### PR TITLE
Add poker room chat and logs

### DIFF
--- a/backend/src/user.service.ts
+++ b/backend/src/user.service.ts
@@ -18,4 +18,9 @@ export class UserService {
     const result = await this.db.query('SELECT * FROM users ORDER BY id');
     return result.rows;
   }
+
+  async getUserById(id: number) {
+    const result = await this.db.query('SELECT * FROM users WHERE id = $1', [id]);
+    return result.rows[0] || null;
+  }
 }


### PR DESCRIPTION
## Summary
- broadcast chat and system log events from backend
- load user name for messages
- display matrix-style chat in poker room

## Testing
- `npm run build` in `backend`
- `npm run build` in `client`
- `./scripts/test_health.sh` *(fails: API did not become healthy)*

------
https://chatgpt.com/codex/tasks/task_e_6874c6d670d88321a99b650131754534